### PR TITLE
column class with fixed types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ select = [
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
 ]
+ignore = ["UP006"]  # Ignore "Use `type` instead of `Type`" warnings
+
 # ignore = [
 #     "E501",  # line too long, handled by black
 #     "B008",  # do not perform function calls in argument defaults
@@ -57,4 +59,10 @@ select = [
 [tool.my-py]
 strict = true
 
+
+[tool.coverage.run]
+omit = [
+  "*/__init__.py",  # Exclude all __init__.py files
+  # Add other patterns if needed, e.g., "*/.venv/*", "*/tests/*", etc.
+]
 

--- a/sweetvalidation/abstracts.py
+++ b/sweetvalidation/abstracts.py
@@ -1,0 +1,60 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractSchema(ABC):
+    """Schema interface.
+    A schema
+    - is a description of the structure of data.
+    - can be used to validate data and to serialize/deserialize data.
+    - consists of three major parts
+        - Metadata: Information that describe the data that follow the schema
+        - Dimensions: Dimensions are columns that fix the domain of the data.
+        - Value: A single value column that represent numerical values
+    """
+
+    # todo need to fix types here
+    dimensions: list
+    value: int
+    metadata: dict
+
+
+class AbstractSchemaRegistry(ABC):
+    """Schema registry interface."""
+
+    @abstractmethod
+    def create(self, name: str):
+        """Create a new schema."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self, name: str) -> None:
+        """Get a schema by name
+
+        Args:
+            name (str): The name of the schema.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete(self, name: str) -> None:
+        """Delete a schema by id.
+
+        Args:
+            name (str): The name of the schema.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def update(self, name: str) -> None:
+        """Update a schema by name.
+
+        Args:
+            name (str): The name of the schema.
+            schema (dict): The schema to update.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def list(self) -> list:
+        """List all schemas."""
+        raise NotImplementedError

--- a/sweetvalidation/models/__init__.py
+++ b/sweetvalidation/models/__init__.py
@@ -1,0 +1,1 @@
+from .columns import *  # noqa

--- a/sweetvalidation/models/columns.py
+++ b/sweetvalidation/models/columns.py
@@ -1,0 +1,63 @@
+from collections.abc import Iterable
+from typing import TypeVar
+
+from pydantic import BaseModel, Field, model_validator
+
+__all__ = ["Column"]
+T = TypeVar("T")
+
+
+class Column(BaseModel):
+    """A column is defined by its name, type, and a human-understandable
+       description of it. A column is assumed to one and exactly one type.
+
+       A column behaves like a list that only allows a certain type and has
+       additional metadata.
+
+    Attributes:
+        name (str): Name of the column
+        ctype (Any): Type of the values in the column
+        description (str): Description of the column content
+    """
+
+    name: str
+    ctype: type[T]
+    description: str
+    items: list[T] | None = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_items(self):
+        for i, item in enumerate(self.items):
+            if not isinstance(item, self.ctype):
+                raise TypeError(
+                    f"Item at index {i} must be of type {self.ctype.__name__}, but found {type(item).__name__}"  # noqa
+                )
+        return self
+
+    def _check_type(self, value: T):
+        if not isinstance(value, self.ctype):
+            raise TypeError(f"Value must be of type {self.ctype.__name__}")
+
+    def __getitem__(self, key: int) -> T:
+        return self.items[key]
+
+    def __delitem__(self, index):
+        del self.items[index]
+
+    def __iter__(self) -> Iterable[T]:
+        return iter(self.items)
+
+    def __contains__(self, item: type[T]) -> bool:
+        return item in self.items
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def append(self, item: type[T]) -> None:
+        self._check_type(item)
+        self.items.append(item)
+
+    def extend(self, iterable: Iterable[T]) -> None:
+        if not all(isinstance(item, self.ctype) for item in iterable):
+            raise TypeError(f"All elements must be of type {self.ctype.__name__}")
+        self.items.extend(iterable)

--- a/sweetvalidation/tests/test_columns.py
+++ b/sweetvalidation/tests/test_columns.py
@@ -1,0 +1,76 @@
+import pytest
+
+from sweetvalidation.models import Column
+
+
+def test_column_create():
+    col = Column(ctype=int, name="test", description="test column")
+    assert col.name == "test"
+    assert col.description == "test column"
+    assert col.ctype.__name__ == "int"
+
+
+def test_column_create_w_items():
+    col = Column(ctype=int, name="test", description="test column", items=[1, 2, 3])
+    assert col.name == "test"
+    assert col.description == "test column"
+    assert col.ctype.__name__ == "int"
+    assert col.items == [1, 2, 3]
+
+    # should raise an error as multiple types are not allowed
+    with pytest.raises(TypeError):
+        Column(ctype=int, name="test", description="test column", items=[1, 2, "3"])
+
+
+def test_column_add_items():
+    col = Column(ctype=int, name="test", description="test column")
+    col.append(1)
+    col.append(2)
+    col.append(3)
+    assert col.items == [1, 2, 3]
+
+    # should raise an error as multiple types are not allowed
+    with pytest.raises(TypeError):
+        col.append("3")
+
+
+def test_column_expand():
+    col = Column(ctype=int, name="test", description="test column")
+    col.extend([1, 2, 3])
+    assert col.items == [1, 2, 3]
+
+    # should raise an error as multiple types are not allowed
+    with pytest.raises(TypeError):
+        col.extend([1, 2, "3"])
+
+
+def test_column_get_item():
+    col = Column(ctype=int, name="test", description="test column", items=[1, 2, 3])
+    assert col[0] == 1
+    assert col[1] == 2
+    assert col[2] == 3
+    # should raise index error
+    with pytest.raises(IndexError):
+        col[3]
+
+
+def test_column_del_item():
+    col = Column(ctype=int, name="test", description="test column", items=[1, 2, 3])
+    del col[0]
+    assert col.items == [2, 3]
+    # should raise index error
+    with pytest.raises(IndexError):
+        del col[2]
+    assert len(col) == 2
+
+
+def test_column_contains():
+    col = Column(ctype=int, name="test", description="test column", items=[1, 2, 3])
+    assert 1 in col
+    assert 4 not in col
+
+
+def test_column_iter():
+    col = Column(ctype=int, name="test", description="test column", items=[1, 2, 3])
+    for i, item in enumerate(col):
+        assert item == i + 1


### PR DESCRIPTION
Columns behave like lists but differ in two important ways:
1. They include additional metadata. In particular, the name of the column and a meaningful description
2. They only allow for a certain type, that must to be set during initialization